### PR TITLE
fix: filter mandatories for persons with duplicate names

### DIFF
--- a/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/index.js
+++ b/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/index.js
@@ -44,6 +44,14 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
       },
     });
 
+    // NOTE (30/10/24): Workaround for the data issue that for some mandatories
+    // their name is stored twice, once with a language tag and once
+    // without. This can be removed again once the data is cleaned up.
+    memberMandatories = memberMandatories.filter(
+      (mandatory, index, memberMandatories) =>
+        index === memberMandatories.findIndex((m) => mandatory.id === m.id)
+    );
+
     let otherMandatories = await this.store.query('mandatory', {
       ...query,
       // mu-cl-resources doesn't support the inverse of `:id:` yet,
@@ -51,6 +59,14 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
       // https://github.com/mu-semtech/mu-cl-resources/issues/22
       ['filter[mandate][role-board][:id:]']: MANDATARIES_ROLES.join(),
     });
+
+    // NOTE (30/10/24): Workaround for the data issue that for some mandatories
+    // their name is stored twice, once with a language tag and once
+    // without. This can be removed again once the data is cleaned up.
+    otherMandatories = otherMandatories.filter(
+      (mandatory, index, otherMandatories) =>
+        index === otherMandatories.findIndex((m) => mandatory.id === m.id)
+    );
 
     return {
       administrativeUnit,


### PR DESCRIPTION
## Context
For some harvested persons Loket contains, and produces, a duplicate given
and/or family names. For instance, a person's given name might be stored twice,
once with a language and once without a language tag. This data is in turn
consumed by WOP, where the frontend does not handle these duplicate names
properly.

## Problem
The mandates page for a worship service's governing body contains tables with
mandates and functionaries. When sorting such a table by given or family name
extra rows will appear when there are duplicate name triples for the person.

Steps to reproduce
1. Launch a local WOP stack with PROD data (Note: use the master branch)
2. Log in as an representative body or municipality with affected worship
   services. The representative body *Aartsbisdom Mechelen-Brussel* and
   municipality of *Leuven* are both related to some the example worship
   services listed in the ticket.
3. In the organisation overview, select a worship service that is affected
   (examples in the ticket)
4. On the following page, select the active governing body
5. On the resulting page, play around with sorting by different columns, you
   should see additional entries (and wrong numbers a the bottom of the table)
   when sorting by name.
   Hint: when sorting on the *Mandaat* column things should look normal.

## Proposed solution
Let the frontend filter duplicate mandates after querying for them. This way
each mandate is only listed once irrelevant of whether it there multiple
given/family name triples.

A disadvantage of this solution is that it does not solve the underlying data
issue. But this is likely not feasible in the short term, and might depend on
the data vendors are providing.

## Related PRs
Same solution applied in [OP's frontend](https://github.com/lblod/frontend-organization-portal/pull/656)

## Related tickets
DL-6189