### PR TITLE
Revert "fix: filter mandatories for persons with duplicate names"

### DIFF
--- a/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/index.js
+++ b/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/index.js
@@ -44,14 +44,6 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
       },
     });
 
-    // NOTE (30/10/24): Workaround for the data issue that for some mandatories
-    // their name is stored twice, once with a language tag and once
-    // without. This can be removed again once the data is cleaned up.
-    memberMandatories = memberMandatories.filter(
-      (mandatory, index, memberMandatories) =>
-        index === memberMandatories.findIndex((m) => mandatory.id === m.id)
-    );
-
     let otherMandatories = await this.store.query('mandatory', {
       ...query,
       // mu-cl-resources doesn't support the inverse of `:id:` yet,
@@ -59,14 +51,6 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
       // https://github.com/mu-semtech/mu-cl-resources/issues/22
       ['filter[mandate][role-board][:id:]']: MANDATARIES_ROLES.join(),
     });
-
-    // NOTE (30/10/24): Workaround for the data issue that for some mandatories
-    // their name is stored twice, once with a language tag and once
-    // without. This can be removed again once the data is cleaned up.
-    otherMandatories = otherMandatories.filter(
-      (mandatory, index, otherMandatories) =>
-        index === otherMandatories.findIndex((m) => mandatory.id === m.id)
-    );
 
     return {
       administrativeUnit,


### PR DESCRIPTION
In #11 a temporary workaround was applied to filter duplicate persons out of the mandatory table. The workaround is no longer needed since the underlying data issues were resolved.

## How to test
1. Launch WOP with PROD data
2. Log in as an representative body or municipality with a worship service that
   was impacted by the original data issue. The representative body *Aartsbisdom
   Mechelen-Brussel* and municipality of *Leuven* are both related to some the
   example worship services listed in the ticket.
3. In the organisation overview, select a worship service that is affected
   (concrete examples in the original ticket OP-3473)
4. On the following page, select the active governing body
5. On the resulting page, there should **not** be duplicate entries in
   tables. For tables with more than 25 entries, pagination should work. Note,
   the initial data issue was related to duplicate names for people, try to play
   around with sorting by different columns to check everything works as
   expected.

## Related tickets
- OP-3541
- OP-3473