### PR TITLE
Rename app from Erediensten Organisaties to Organisaties Erediensten

### DIFF
--- a/app/components/static-page.hbs
+++ b/app/components/static-page.hbs
@@ -1,6 +1,6 @@
 <AuContentHeader
   @titlePartOne="Vlaanderen"
-  @titlePartTwo="is het Erediensten Organisaties"
+  @titlePartTwo="is het Organisaties Erediensten"
 >
   <img
     sizes="50vw"

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,6 @@
 {{page-title
   (concat
-    'Organisatie Portaal' (if this.showEnvironment (concat ' - ' this.environmentName))
+    'Organisaties Erediensten' (if this.showEnvironment (concat ' - ' this.environmentName))
   )
 }}
 

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -3,7 +3,7 @@
     <div class="au-o-grid au-o-grid--small">
       <div class="au-o-grid__item au-u-3-4@small au-u-1-2@medium">
         <AuContent @skin="large">
-          <h1>Erediensten Organisaties</h1>
+          <h1>Organisaties Erediensten</h1>
           <p class="au-c-heading au-c-heading--4">Een webapplicatie die helpt met
             het visualiseren van data over besturen van een eredienst
             en personen.</p>
@@ -27,7 +27,7 @@
   <section class="au-o-region-large au-u-background-gray-200">
     <div class="au-o-layout">
       <AuHeading @level="2" @skin="3" class="au-u-margin-bottom">
-        De functionaliteiten van Erediensten Organisaties
+        De functionaliteiten van Organisaties Erediensten
       </AuHeading>
       <div class="au-o-grid au-o-grid--small">
         <div class="au-o-grid__item au-u-1-2@small">

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,7 +38,7 @@ module.exports = function (environment) {
         message: '{{ANNOUNCE_TESTING_MESSAGE}}',
       },
     },
-    appName: 'EredienstenOrganisaties',
+    appName: 'Organisaties Erediensten',
     contactEmail: 'organisaties.abb@vlaanderen.be',
     environmentName: '{{ENVIRONMENT_NAME}}',
     environmentTitle: '{{ENVIRONMENT_TITLE}}',


### PR DESCRIPTION
[DL-6960]

Rename app from Erediensten Organisaties to Organisaties Erediensten.

You can check it via running the frontend against the dev backend:
```
ember serve --proxy https://dev.organisaties.lokaalbestuur.lblod.info
```