### PR TITLE
Add test pr woodpecker pipeline

### DIFF
--- a/.woodpecker/.test-pr.yml
+++ b/.woodpecker/.test-pr.yml
@@ -1,0 +1,34 @@
+steps:
+  install:
+    image: danlynn/ember-cli:4.12.1
+    commands:
+      - npm ci
+  lint-js:
+    image: danlynn/ember-cli:4.12.1
+    depends_on: install
+    commands:
+      - npm run lint:js
+  lint-hbs:
+    image: danlynn/ember-cli:4.12.1
+    depends_on: install
+    commands:
+      - npm run lint:hbs
+  lint-css:
+    image: danlynn/ember-cli:4.12.1
+    depends_on: install
+    commands:
+      - npm run lint:css
+  dependency-lint:
+    image: danlynn/ember-cli:4.12.1
+    depends_on: install
+    commands:
+      - ember dependency-lint
+    # Ignore fail until the dependency lint errors are fixed
+    failure: ignore
+  test:
+    image: danlynn/ember-cli:4.12.1
+    depends_on: [lint-js, lint-hbs, lint-css, dependency-lint]
+    commands:
+      - npm run test:ember
+when:
+  - event: pull_request


### PR DESCRIPTION
As Sam noticed in #15, we were missing the `test-pr` woodpecker pipeline, which might cause the introduction of linting errors without us noticing. This PR adds it.